### PR TITLE
fix: Restore ability to handle relative paths in `pytest.mark.vcr`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Changed
+~~~~~~~
+
+- Restore undocumented ability to use relative paths in ``pytest.mark.vcr``. `#34`_
+
 `0.5.0`_ - 2020-01-09
 ---------------------
 
@@ -107,6 +112,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#34: https://github.com/kiwicom/pytest-recording/issues/34
 .. _#20: https://github.com/kiwicom/pytest-recording/issues/20
 .. _#10: https://github.com/kiwicom/pytest-recording/issues/10
 .. _#8: https://github.com/kiwicom/pytest-recording/issues/8

--- a/tests/test_replaying.py
+++ b/tests/test_replaying.py
@@ -364,3 +364,24 @@ def test_feature():
     create_file("cassettes/test_default_cassette_always_exist/test_feature.yaml", ip_cassette)
     result = testdir.runpytest()
     result.assert_outcomes(passed=1)
+
+
+def test_relative_cassette_path(testdir, create_file, ip_cassette, get_cassette):
+    # When a relative path is used in `pytest.mark.vcr`
+    testdir.makepyfile(
+        """
+import pytest
+import requests
+
+
+@pytest.mark.vcr("ip_cassette.yaml")
+def test_feature():
+    assert requests.get("http://httpbin.org/get").text == '{"get": true}'
+    assert requests.get("http://httpbin.org/ip").text == '{"ip": true}'
+    """
+    )
+    create_file("cassettes/test_relative_cassette_path/test_feature.yaml", get_cassette)
+    create_file("cassettes/test_relative_cassette_path/ip_cassette.yaml", ip_cassette)
+    result = testdir.runpytest()
+    # Then it should be properly loaded and used
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
Fixes #34 