### PR TITLE
fix: `TypeError` when using network blocking with address as `bytes` or `bytearray`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- ``TypeError`` when using network blocking with address as ``bytes`` or ``bytearray``. `#55`_
+
 Removed
 ~~~~~~~
 
@@ -148,6 +153,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#55: https://github.com/kiwicom/pytest-recording/issues/55
 .. _#53: https://github.com/kiwicom/pytest-recording/issues/53
 .. _#47: https://github.com/kiwicom/pytest-recording/issues/47
 .. _#45: https://github.com/kiwicom/pytest-recording/issues/45

--- a/src/pytest_recording/network.py
+++ b/src/pytest_recording/network.py
@@ -155,9 +155,15 @@ def blocking_context(allowed_hosts=None):
         unblock()
 
 
+def to_string(value):
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    return value
+
+
 def is_host_in_allowed_hosts(host, allowed_hosts):
     """Match provided host to a list of host regexps."""
     if allowed_hosts is not None:
         combined = "(" + ")|(".join(allowed_hosts) + ")"
-        return re.match(combined, host)
+        return re.match(combined, to_string(host))
     return False

--- a/tests/test_blocking_network.py
+++ b/tests/test_blocking_network.py
@@ -149,11 +149,24 @@ def test_with_vcr_mark(httpbin):
 def test_no_vcr_mark(httpbin):
     with pytest.raises(RuntimeError, match=r"^Network is disabled$"):
         requests.get(httpbin.url + "/ip")
+
+
+@pytest.mark.block_network(allowed_hosts=["127.0.0.2"])
+def test_no_vcr_mark_bytes():
+    with pytest.raises(RuntimeError, match=r"^Network is disabled$"):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect((b"127.0.0.1", 80))
+
+@pytest.mark.block_network(allowed_hosts=["127.0.0.2"])
+def test_no_vcr_mark_bytearray():
+    with pytest.raises(RuntimeError, match=r"^Network is disabled$"):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.connect((bytearray(b"127.0.0.1"), 80))
     """
     )
 
-    result = testdir.runpytest()
-    result.assert_outcomes(passed=2)
+    result = testdir.runpytest("-s")
+    result.assert_outcomes(passed=4)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #55 