### PR TITLE
chore: Validate input arguments for `vcr` and `block_network` pytest marks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Changed
+~~~~~~~
+
+- Validate input arguments for ``vcr`` and ``block_network`` pytest marks. `#69`_
+
 `0.11.0`_ - 2020-11-25
 ----------------------
 
@@ -180,6 +185,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#69: https://github.com/kiwicom/pytest-recording/issues/69
 .. _#64: https://github.com/kiwicom/pytest-recording/issues/64
 .. _#55: https://github.com/kiwicom/pytest-recording/issues/55
 .. _#53: https://github.com/kiwicom/pytest-recording/issues/53

--- a/src/pytest_recording/exceptions.py
+++ b/src/pytest_recording/exceptions.py
@@ -1,0 +1,4 @@
+class UsageError(Exception):
+    """Error in plugin usage."""
+
+    __module__ = "builtins"

--- a/src/pytest_recording/plugin.py
+++ b/src/pytest_recording/plugin.py
@@ -10,6 +10,7 @@ from vcr.cassette import Cassette
 
 from . import hooks, network
 from ._vcr import use_cassette
+from .validation import validate_block_network_mark
 
 RECORD_MODES = ("once", "new_episodes", "none", "all", "rewrite")
 
@@ -91,6 +92,8 @@ def vcr_markers(request: SubRequest) -> List[Mark]:
 def block_network(request: SubRequest, record_mode: str) -> Iterator[None]:
     """Block network access in tests except for "none" VCR recording mode."""
     marker = request.node.get_closest_marker(name="block_network")
+    if marker is not None:
+        validate_block_network_mark(marker)
     # If network blocking is enabled there is one exception - if VCR is in recording mode (any mode except "none")
     default_block = marker or request.config.getoption("--block-network")
     allowed_hosts = getattr(marker, "kwargs", {}).get("allowed_hosts") or request.config.getoption("--allowed-hosts")

--- a/src/pytest_recording/validation.py
+++ b/src/pytest_recording/validation.py
@@ -1,0 +1,16 @@
+from _pytest.mark import Mark
+
+from .exceptions import UsageError
+
+ALLOWED_BLOCK_NETWORK_ARGUMENTS = ["allowed_hosts"]
+
+
+def validate_block_network_mark(mark: Mark) -> None:
+    """Validate the input arguments for the `block_network` pytest mark."""
+    if mark.args or list(mark.kwargs) not in ([], ALLOWED_BLOCK_NETWORK_ARGUMENTS):
+        allowed_arguments = ", ".join("`{}`".format(arg) for arg in ALLOWED_BLOCK_NETWORK_ARGUMENTS)
+        raise UsageError(
+            "Invalid arguments to `block_network`. "
+            "It accepts only the following keyword arguments: {}. "
+            "Got args: {!r}; kwargs: {!r}".format(allowed_arguments, mark.args, mark.kwargs)
+        )

--- a/tests/test_blocking_network.py
+++ b/tests/test_blocking_network.py
@@ -400,3 +400,25 @@ def test_critical_error():
     result.assert_outcomes(passed=1)
     # NOTE. In reality it is not likely to happen - e.g. if pytest will partially crash and will not call the teardown
     # part of the generator, but this try/finally implementation could also guard against errors on manual
+
+
+@pytest.mark.parametrize("args", ("foo=42", "42"))
+def test_invalid_input_arguments(testdir, args):
+    # When the `block_network` mark receives an unknown argument
+    testdir.makepyfile(
+        """
+import pytest
+import requests
+
+@pytest.mark.block_network({})
+def test_request():
+    requests.get("https://google.com")
+    """.format(
+            args
+        )
+    )
+    result = testdir.runpytest()
+    # Then there should be an error
+    result.assert_outcomes(errors=1)
+    expected = "Invalid arguments to `block_network`. It accepts only the following keyword arguments: `allowed_hosts`."
+    assert expected in result.stdout.str()


### PR DESCRIPTION
Resolves #69

- [ ] Validate the `vcr` mark as well.
- [x] Prettify the exception path. `_pytest.config.exceptions.UsageError` -> `UsageError`.
