### PR TITLE
fix: Honor `record_mode` set via the `vcr_config` fixture or the `vcr` mark when `block_network` is applied

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,11 @@ Changelog
 `Unreleased`_
 -------------
 
+Fixed
+~~~~~
+
+- Honor ``record_mode`` set via the ``vcr_config`` fixture or the ``vcr`` mark when ``block_network`` is applied. `#68`_
+
 Changed
 ~~~~~~~
 
@@ -186,6 +191,7 @@ Added
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
 .. _#69: https://github.com/kiwicom/pytest-recording/issues/69
+.. _#68: https://github.com/kiwicom/pytest-recording/issues/68
 .. _#64: https://github.com/kiwicom/pytest-recording/issues/64
 .. _#55: https://github.com/kiwicom/pytest-recording/issues/55
 .. _#53: https://github.com/kiwicom/pytest-recording/issues/53

--- a/tests/test_blocking_network.py
+++ b/tests/test_blocking_network.py
@@ -10,8 +10,18 @@ except ImportError as exc:
     pycurl = None
 
 
-def test_blocked_network_recording(testdir):
-    # When record is enabled
+def assert_network_blocking(testdir, dirname):
+    result = testdir.runpytest("--record-mode=all")
+    # Then all network requests in tests with block_network mark except for marked with pytest.mark.vcr should fail
+    result.assert_outcomes(passed=3)
+
+    # And a cassette is recorded for the case where pytest.mark.vcr is applied
+    cassette_path = testdir.tmpdir.join("cassettes/{}/test_recording.yaml".format(dirname))
+    assert cassette_path.exists()
+
+
+def test_blocked_network_recording_cli_arg(testdir):
+    # When record is enabled via a CLI arg
     testdir.makepyfile(
         """
 import pytest
@@ -31,14 +41,60 @@ def test_error(httpbin):
         assert requests.get(httpbin.url + "/ip").status_code == 200
     """
     )
+    assert_network_blocking(testdir, "test_blocked_network_recording_cli_arg")
 
-    result = testdir.runpytest("--record-mode=all")
-    # Then all network requests in tests with block_network mark except for marked with pytest.mark.vcr should fail
-    result.assert_outcomes(passed=3)
 
-    # And a cassette is recorded for the case where pytest.mark.vcr is applied
-    cassette_path = testdir.tmpdir.join("cassettes/test_blocked_network_recording/test_recording.yaml")
-    assert cassette_path.exists()
+def test_blocked_network_recording_vcr_config(testdir):
+    # When record is enabled via the `vcr_config` fixture
+    testdir.makepyfile(
+        """
+import pytest
+import requests
+
+@pytest.fixture(autouse=True)
+def vcr_config():
+    return {"record_mode": "once"}
+
+
+def test_no_blocking(httpbin):
+    assert requests.get(httpbin.url + "/ip").status_code == 200
+
+@pytest.mark.block_network
+@pytest.mark.vcr
+def test_recording(httpbin):
+    assert requests.get(httpbin.url + "/ip").status_code == 200
+
+@pytest.mark.block_network
+def test_error(httpbin):
+    with pytest.raises(RuntimeError, match=r"^Network is disabled$"):
+        assert requests.get(httpbin.url + "/ip").status_code == 200
+    """
+    )
+    assert_network_blocking(testdir, "test_blocked_network_recording_vcr_config")
+
+
+def test_blocked_network_recording_vcr_mark(testdir):
+    # When record is enabled via the `vcr` mark
+    testdir.makepyfile(
+        """
+import pytest
+import requests
+
+def test_no_blocking(httpbin):
+    assert requests.get(httpbin.url + "/ip").status_code == 200
+
+@pytest.mark.block_network
+@pytest.mark.vcr(record_mode="once")
+def test_recording(httpbin):
+    assert requests.get(httpbin.url + "/ip").status_code == 200
+
+@pytest.mark.block_network
+def test_error(httpbin):
+    with pytest.raises(RuntimeError, match=r"^Network is disabled$"):
+        assert requests.get(httpbin.url + "/ip").status_code == 200
+    """
+    )
+    assert_network_blocking(testdir, "test_blocked_network_recording_vcr_mark")
 
 
 def test_socket_connect(testdir):


### PR DESCRIPTION
Fixes #68