### PR TITLE
Feature: Allow block_network.allowed_hosts configuration via fixture

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -194,6 +194,17 @@ Or via command-line option:
 
     $ pytest --record-mode=once --block-network --allowed-hosts=httpbin.*,localhost tests/
 
+
+Or via `vcr_config` fixture:
+
+.. code:: python
+
+    import pytest
+
+    @pytest.fixture(autouse=True)
+    def vcr_config():
+        return {"allowed_hosts": ["httpbin.*"]}
+
 Additional resources
 --------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 `Unreleased`_
 -------------
 
-- Allow ``block_network.allowed_hosts`` configuration via ``vcr_config`` fixture. #82
+- Allow ``block_network.allowed_hosts`` configuration via ``vcr_config`` fixture. `#82`_
 
 `0.12.0`_ - 2021-07-08
 ----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 `Unreleased`_
 -------------
 
-- Allow ``block_network.allowed_hosts`` configuration via ``vcr_config`` fixture. `#82`_
+- Allow ``block_network.allowed_hosts`` configuration via ``vcr_config`` fixture. #82
 
 `0.12.0`_ - 2021-07-08
 ----------------------
@@ -196,6 +196,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#82: https://github.com/kiwicom/pytest-recording/pull/82
 .. _#69: https://github.com/kiwicom/pytest-recording/issues/69
 .. _#68: https://github.com/kiwicom/pytest-recording/issues/68
 .. _#64: https://github.com/kiwicom/pytest-recording/issues/64

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 `Unreleased`_
 -------------
 
+- Allow ``block_network.allowed_hosts`` configuration via ``vcr_config`` fixture. #82
+
 `0.12.0`_ - 2021-07-08
 ----------------------
 

--- a/src/pytest_recording/plugin.py
+++ b/src/pytest_recording/plugin.py
@@ -101,7 +101,11 @@ def block_network(request: SubRequest, record_mode: str, vcr_markers: List[Mark]
     #  - CLI option
     #  - vcr_config fixture
     default_block = marker or request.config.getoption("--block-network")
-    allowed_hosts = getattr(marker, "kwargs", {}).get("allowed_hosts") or request.config.getoption("--allowed-hosts") or config.get("allowed_hosts")
+    allowed_hosts = (
+        getattr(marker, "kwargs", {}).get("allowed_hosts")
+        or request.config.getoption("--allowed-hosts")
+        or config.get("allowed_hosts")
+    )
     if isinstance(allowed_hosts, str):
         allowed_hosts = allowed_hosts.split(",")
     if vcr_markers:


### PR DESCRIPTION
### Description

Extended `pytest_recording.plugin.block_network` to allow configuration of allowed_hosts via `vcr_config` fixture.

I had to version pin werkzeug<2.1.0 to avoid https://github.com/postmanlabs/httpbin/issues/673, not sure if you would like to move this change to a separate PR :) 

### Checklist

- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [x] Extended the README / documentation, if necessary
