### PR TITLE
Python 3.10 & 3.11 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,23 +62,34 @@ jobs:
 
   tests:
     name: tests_${{ matrix.tox_job }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os_version }}
     strategy:
       matrix:
-        tox_job: [py35, py36, py37, py38, py39, no_pycurl]
         include:
           - tox_job: py35
-            python: 3.5
+            python: "3.5"
+            os_version: "ubuntu-20.04"
           - tox_job: py36
-            python: 3.6
+            python: "3.6"
+            os_version: "ubuntu-20.04"
           - tox_job: py37
-            python: 3.7
+            python: "3.7"
+            os_version: "ubuntu-latest"
           - tox_job: py38
-            python: 3.8
+            python: "3.8"
+            os_version: "ubuntu-latest"
           - tox_job: py39
-            python: 3.9
+            python: "3.9"
+            os_version: "ubuntu-latest"
           - tox_job: no_pycurl
-            python: 3.8
+            python: "3.8"
+            os_version: "ubuntu-latest"
+          - tox_job: py310
+            python: "3.10"
+            os_version: "ubuntu-latest"
+          - tox_job: py311
+            python: "3.11"
+            os_version: "ubuntu-latest"
 
     steps:
       - uses: actions/checkout@v3

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -50,7 +50,7 @@ Submitting Pull Requests
 #. Follow **PEP-8** for naming and `black <https://github.com/psf/black>`_ for formatting.
 #. Tests are run using ``tox``::
 
-    tox -e pylint,mypy,py37
+    tox -e pylint,py37
 
    The test environments above are usually enough to cover most cases locally.
 

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ Python support
 
 Pytest-recording supports:
 
-- CPython 3.5, 3.6, 3.7, 3.8 and 3.9.
+- CPython 3.5, 3.6, 3.7, 3.8, 3.9, 3.10 and 3.11
 - PyPy 7 (3.6)
 
 License

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 `Unreleased`_
 -------------
 
+- Add support for Python 3.10 and 3.11. `#99`_
+
 `0.12.1`_ - 2022-06-20
 ----------------------
 
@@ -200,6 +202,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#99: https://github.com/kiwicom/pytest-recording/pull/99
 .. _#82: https://github.com/kiwicom/pytest-recording/pull/82
 .. _#69: https://github.com/kiwicom/pytest-recording/issues/69
 .. _#68: https://github.com/kiwicom/pytest-recording/issues/68

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Operating System :: OS Independent",

--- a/tests/test_blocking_network.py
+++ b/tests/test_blocking_network.py
@@ -417,7 +417,7 @@ def test_pycurl_url_error():
     # And a wrapper may fail on URL manipulation due to missing URL
     curl = pycurl.Curl()
     # Then original pycurl error must be raised
-    with pytest.raises(pycurl.error, match="No URL set!"):
+    with pytest.raises(pycurl.error, match="No URL set"):
         curl.perform()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pylint,py{35,36,37,38,39,py3},no_pycurl,coverage-report
+envlist = pylint,py{35,36,37,38,39,310,311,py3},no_pycurl,coverage-report
 
 [testenv]
 setenv =
@@ -43,7 +43,7 @@ description = Report coverage over all measured test runs.
 basepython = python3.8
 deps = coverage
 skip_install = true
-depends = {py35,py36,py37,py38,py39,pypy3}
+depends = {py35,py36,py37,py38,py39,py310,py311,pypy3}
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
### Description

- Add Python 3.10 & 3.11
- fix contributing.rst: it mentioned the non-existent mypy environment
- fix the regex in `test_pycurl_url_error` (it contained a `!` that got removed)

### Checklist

- [x] ~~Created tests which fail without the change (if possible)~~
- [x] All tests passing
- [x] Added a changelog entry
- [x] Extended the README / documentation, if necessary


This fixes https://github.com/kiwicom/pytest-recording/issues/96