### PR TITLE
update pre-commit, fix pylint error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - run: pip install pre-commit
       - run: SKIP=pylint,mypy pre-commit run --all-files
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - run: pip install pre-commit
       - run: pre-commit run pylint --all-files
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
 
       - run: pip install pre-commit
       - run: pre-commit run mypy --all-files
@@ -66,12 +66,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - tox_job: py35
-            python: "3.5"
-            os_version: "ubuntu-20.04"
-          - tox_job: py36
-            python: "3.6"
-            os_version: "ubuntu-20.04"
           - tox_job: py37
             python: "3.7"
             os_version: "ubuntu-latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: 3.11
     - name: Install tox
       run: >-
         python -m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 default_language_version:
-  python: python3.7
+  python: python3.11
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -15,43 +15,42 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.17.0
+    rev: v0.19.1
     hooks:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.32.0
     hooks:
       - id: yamllint
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.34.0
     hooks:
       - id: markdownlint
         language_version: system
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
 
   - repo: https://github.com/codingjoe/relint
-    rev: 1.2.1
+    rev: 3.0.0
     hooks:
       - id: relint
 
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black
         types: [python]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.961
+    rev: v1.3.0
     hooks:
       - id: mypy
         exclude: ^(docs/|tests/|setup.py).*$
-        args: ["--ignore-missing-imports"]
         additional_dependencies: [ "types-attrs", "types-pycurl" ]
 
   - repo: https://github.com/asottile/seed-isort-config

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,8 +1,8 @@
 [mypy]
-python_version = 3.5
+python_version = 3.11
 show_error_context = true
 verbosity = 0
-ignore_missing_imports = true
+ignore_missing_imports = false
 show_traceback = true
 check_untyped_defs = true
 cache_fine_grained = true

--- a/src/pytest_recording/_vcr.py
+++ b/src/pytest_recording/_vcr.py
@@ -32,7 +32,11 @@ class CombinedPersister(FilesystemPersister):
 
     extra_paths = attr.ib(type=List[str])
 
-    def load_cassette(self, cassette_path: str, serializer: ModuleType) -> Tuple[List, List]:
+    # FilesystemPersister.load_casette is a classmethod, which
+    # is likely why pylint gives an error.
+    def load_cassette(  # pylint: disable=arguments-differ
+        self, cassette_path: str, serializer: ModuleType
+    ) -> Tuple[List, List]:
         all_paths = chain.from_iterable(((cassette_path,), self.extra_paths))
         # Pairs of 2 lists per cassettes:
         all_content = (load_cassette(path, serializer) for path in unique(all_paths))

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ deps =
   pylint
   pytest
   vcrpy
+  attr
 commands = pylint {posargs:} src/pytest_recording
 
 [testenv:coverage-report]


### PR DESCRIPTION
### Description
Fixes everything in #105, other than pypy3+pycurl
Also updates pre-commit config, and updates python version in it. python3.7 was unsupported by `relint`

### Checklist

- [ ] ~~Created tests which fail without the change (if possible)~~
- [x] All tests passing (except pypy3)
- [ ] ~~Added a changelog entry~~
- [ ] ~~Extended the README / documentation, if necessary~~
