### PR TITLE
Support vcrpy v5

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 -------------
 
 - Drop support for Python 3.5 and 3.6. `#97`_
+- Support `vcrpy v5 <https://github.com/kevin1024/vcrpy/releases/tag/v5.0.0>`_. `#110`_
 
 `0.12.2`_ - 2023-02-16
 ----------------------
@@ -208,6 +209,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#110: https://github.com/kiwicom/pytest-recording/pull/110
 .. _#99: https://github.com/kiwicom/pytest-recording/pull/99
 .. _#97: https://github.com/kiwicom/pytest-recording/issues/97
 .. _#82: https://github.com/kiwicom/pytest-recording/pull/82

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-install_requires = ["vcrpy>=2.0.1,<5", "pytest>=3.5.0", "attrs"]
+install_requires = ["vcrpy>=2.0.1", "pytest>=3.5.0", "attrs"]
 
 
 def read(fname):

--- a/src/pytest_recording/_vcr.py
+++ b/src/pytest_recording/_vcr.py
@@ -12,6 +12,7 @@ from vcr.cassette import CassetteContextDecorator
 from vcr.persisters.filesystem import FilesystemPersister
 from vcr.serialize import deserialize
 
+from .exceptions import CassetteNotFoundError
 from .utils import unique, unpack
 
 ConfigType = Dict[str, Any]
@@ -49,7 +50,7 @@ class CombinedPersister(FilesystemPersister):
         requests, responses = starmap(unpack, zip(*all_content))
         requests, responses = list(requests), list(responses)
         if not requests or not responses:
-            raise ValueError("No cassettes found.")
+            raise CassetteNotFoundError("No cassettes found.")
         return requests, responses
 
 

--- a/src/pytest_recording/exceptions.py
+++ b/src/pytest_recording/exceptions.py
@@ -1,4 +1,16 @@
+try:
+    from vcr.cassette import CassetteNotFoundError
+except ImportError:
+    # Required until vcrpy minimum version is v5.0.0, avoid type checking to
+    # skip no-redef
+    class CassetteNotFoundError(ValueError):  # type: ignore
+        pass
+
+
 class UsageError(Exception):
     """Error in plugin usage."""
 
     __module__ = "builtins"
+
+
+__all__ = ["UsageError", "CassetteNotFoundError"]


### PR DESCRIPTION
### Description

v5 requires a `CassetteNotFoundError` to be raised instead of a `ValueError` in the custom persistor. We just create our own version of the error if vcrpy version is below v5.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
