### PR TITLE
Update supported VCR versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import find_packages, setup
 
-install_requires = ["vcrpy>=2.0.1", "pytest>=3.5.0", "attrs"]
+install_requires = ["vcrpy>=2.0.1,<4.4.0", "pytest>=3.5.0", "attrs"]
 
 
 def read(fname):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pylint,py{35,36,37,38,39,310,311,py3},no_pycurl,coverage-report
+envlist = pylint,py{37,38,39,310,311,py3},no_pycurl,coverage-report
 
 [testenv]
 setenv =
@@ -44,7 +44,7 @@ description = Report coverage over all measured test runs.
 basepython = python3.8
 deps = coverage
 skip_install = true
-depends = {py35,py36,py37,py38,py39,py310,py311,pypy3}
+depends = {py37,py38,py39,py310,py311,pypy3}
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
I do not intend to release this as is, but it is an improvement over the status quo as it clearly sets the supported VCRpy versions instead of failing in runtime (or, at least the end-user will be notified about incompatibilities by their package manager). Then we can gradually add support for newer VCRpy versions in separate PRs.