### PR TITLE
chore: add trove classifier for license

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,8 @@ Changelog
 `Unreleased`_
 -------------
 
+- Add trove classifier for license.
+
 `0.13.0`_ - 2023-08-01
 ----------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Pytest",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
     "Topic :: Software Development :: Testing",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
### Description

PyPI and various other tools don't report any license for pytest-recording.

Apparently, these tools rely on the trove classifier, not on the license setting in pyproject.toml or the LICENSE file in the project tree.

Add the trove classifier for consistency and compatibility with these tools.

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
