### PR TITLE
Adds example of accessing VCR Cassette object in tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,15 @@ Usage
         assert requests.get("http://httpbin.org/get").text == '{"get": true}'
         assert requests.get("http://httpbin.org/ip").text == '{"ip": true}'
 
+    # Make assertions based on the cassette calls/responses:
+    @pytest.mark.vcr
+    def test_call_count(vcr):
+        assert requests.get("http://httpbin.org/get").text == '{"get": true}'
+        assert requests.get("http://httpbin.org/ip").text == '{"ip": true}'
+        # See https://vcrpy.readthedocs.io/en/latest/advanced.html for more info
+        # about the Cassette object:
+        assert vcr.play_count == 2
+
 Run your tests:
 
 .. code:: bash

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 `Unreleased`_
 -------------
+- Documentation improvements.
 
 `0.13.1`_ - 2023-12-07
 ----------------------


### PR DESCRIPTION
🚨Please review the
[guidelines for contributing](https://github.com/kiwicom/pytest-recording/blob/master/CONTRIBUTING.rst)
to this repository.

### Description

Adds an example showing how to access the VCR Cassette ojbect in a pytest (https://vcrpy.readthedocs.io/en/latest/advanced.html)

### Checklist

- [-] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [x] Extended the README / documentation, if necessary
