### PR TITLE
feat: "Lazy load" VCR to reduce plugin overhead

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 
 `Unreleased`_
 -------------
+- Add lazy loading of VCR to reduce plugin overhead. `#145`_
 - Documentation improvements.
 
 `0.13.1`_ - 2023-12-07
@@ -223,6 +224,7 @@ Added
 .. _0.3.0: https://github.com/kiwicom/pytest-recording/compare/v0.2.0...v0.3.0
 .. _0.2.0: https://github.com/kiwicom/pytest-recording/compare/v0.1.0...v0.2.0
 
+.. _#145: https://github.com/kiwicom/pytest-recording/issues/145
 .. _#118: https://github.com/kiwicom/pytest-recording/pull/118
 .. _#99: https://github.com/kiwicom/pytest-recording/pull/99
 .. _#97: https://github.com/kiwicom/pytest-recording/issues/97

--- a/src/pytest_recording/_vcr.py
+++ b/src/pytest_recording/_vcr.py
@@ -1,9 +1,8 @@
 import os
-from copy import deepcopy
 from dataclasses import dataclass
 from itertools import chain, starmap
 from types import ModuleType
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Callable, List, Tuple
 
 from _pytest.config import Config
 from _pytest.mark.structures import Mark
@@ -19,9 +18,7 @@ except ImportError:
     # VCR.py <5
     CassetteNotFoundError = ValueError
 
-from .utils import unique, unpack
-
-ConfigType = Dict[str, Any]
+from .utils import ConfigType, merge_kwargs, unique, unpack
 
 
 def load_cassette(cassette_path: str, serializer: ModuleType) -> Tuple[List, List]:
@@ -104,11 +101,3 @@ def get_path_transformer(config: ConfigType) -> Callable:
     else:
         suffix = ".yaml"
     return VCR.ensure_suffix(suffix)
-
-
-def merge_kwargs(config: ConfigType, markers: List[Mark]) -> ConfigType:
-    """Merge all kwargs into a single dictionary to pass to `vcr.use_cassette`."""
-    kwargs = deepcopy(config)
-    for marker in reversed(markers):
-        kwargs.update(marker.kwargs)
-    return kwargs

--- a/src/pytest_recording/hooks.py
+++ b/src/pytest_recording/hooks.py
@@ -1,6 +1,9 @@
 from _pytest.config import Config
-from vcr import VCR
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vcr import VCR
 
 
-def pytest_recording_configure(config: Config, vcr: VCR) -> None:
+def pytest_recording_configure(config: Config, vcr: "VCR") -> None:
     pass  # pragma: no cover

--- a/src/pytest_recording/plugin.py
+++ b/src/pytest_recording/plugin.py
@@ -1,15 +1,17 @@
 import os
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, TYPE_CHECKING
 
 import pytest
 from _pytest.config import Config, PytestPluginManager
 from _pytest.config.argparsing import Parser
 from _pytest.fixtures import SubRequest
 from _pytest.mark.structures import Mark
-from vcr.cassette import Cassette
+
+if TYPE_CHECKING:
+    from vcr.cassette import Cassette
 
 from . import hooks, network
-from ._vcr import merge_kwargs, use_cassette
+from .utils import merge_kwargs
 from .validation import validate_block_network_mark
 
 RECORD_MODES = ("once", "new_episodes", "none", "all", "rewrite")
@@ -144,11 +146,13 @@ def vcr(
     record_mode: str,
     disable_recording: bool,
     pytestconfig: Config,
-) -> Iterator[Optional[Cassette]]:
+) -> Iterator[Optional["Cassette"]]:
     """Install a cassette if a test is marked with `pytest.mark.vcr`."""
     if disable_recording:
         yield None
     elif vcr_markers:
+        from ._vcr import use_cassette
+
         config = request.getfixturevalue("vcr_config")
         default_cassette = request.getfixturevalue("default_cassette_name")
         with use_cassette(

--- a/src/pytest_recording/utils.py
+++ b/src/pytest_recording/utils.py
@@ -1,5 +1,9 @@
+from copy import deepcopy
 from itertools import chain
-from typing import Any, Iterable, Iterator
+from typing import Any, Dict, Iterable, Iterator, List
+from _pytest.mark.structures import Mark
+
+ConfigType = Dict[str, Any]
 
 
 def unique(sequence: Iterable) -> Iterator:
@@ -12,3 +16,11 @@ def unique(sequence: Iterable) -> Iterator:
 
 def unpack(*args: Any) -> Iterable:
     return chain.from_iterable(args)
+
+
+def merge_kwargs(config: ConfigType, markers: List[Mark]) -> ConfigType:
+    """Merge all kwargs into a single dictionary to pass to `vcr.use_cassette`."""
+    kwargs = deepcopy(config)
+    for marker in reversed(markers):
+        kwargs.update(marker.kwargs)
+    return kwargs


### PR DESCRIPTION
### Description

This PR defers importing `_vcr` in `plugin.py` until the `vcr` fixture is invoked with a vcr-marked test. The `merge_kwargs` helper has been moved to `utils.py` to allow importing it independently of the VCR modules required by `_vcr.py`. VCR object imports are now guarded using `if TYPE_CHECKING`.

To verify the performance improvement, I compared the results of running the same dummy test case with and without the vcr mark. I averaged results from running pytest 20 times, removing `__pycache__` and `.pytest_cache` between runs. Here is a summary of the results:

| `pytest_recording` version | Unmarked Test Runtime | `@pytest.mark.vcr` Runtime |
| --- | --- | --- |
| 0.13.1 | 291.47 ms | 287.70 ms |
| This change | **140.39 ms** | 294.15 ms |

The results show a significant improvement in the runtime of unmarked tests, while the runtime of tests marked with `@pytest.mark.vcr` remains comparable to the previous version.

### Checklist

- [N/A] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Added a changelog entry
- [N/A] Extended the README / documentation, if necessary

