### PR TITLE
various small fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        additional_dependencies: [ "types-pycurl", "types-PyYAML" ]
+        additional_dependencies: [ "types-pycurl", "types-PyYAML", "types-requests" ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.5

--- a/.relint.yml
+++ b/.relint.yml
@@ -1,24 +1,11 @@
-- name: Fix it now
-  pattern: "[fF][iI][xX][mM][eE]"
-  filename:
-    - "*.py"
-
 - name: No sys.path changes
   pattern: "sys\\.path\\.append|sys\\.path\\.insert"
-  filename:
-    - "src/**.py"
+  filePattern: src/.*\.py
 
 - name: IPython debug leftover
   pattern: "IPython\\.embed()"
-  filename:
-    - "*.py"
-
-- name: Leftover print
-  pattern: "print\\("
-  filename:
-    - ^(?!.*conftest).*\.py$
+  filePattern: .*\.py
 
 - name: Use relative imports
   pattern: "import pytest_recording|from pytest_recording"
-  filename:
-    - "src/**.py"
+  filePattern: src/.*\.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ recording = "pytest_recording.plugin"
 
 [tool.ruff]
 line-length = 120
+target-version = "py39"
+
+[tool.ruff.lint]
 select = [
     "E", # pycodestyle errors
     "W", # pycodestyle warnings
@@ -62,6 +65,9 @@ select = [
     "C", # flake8-comprehensions
     "B", # flake8-bugbear
     "D", # pydocstyle
+    "I", # isort
+    "T", # prints
+    "FIX", # fixme comments
 ]
 ignore = [
     "E501", # Line too long, handled by ruff
@@ -78,11 +84,10 @@ ignore = [
     "D213", # Multiline summary second line
     "D401", # Imperative mood
 ]
-target-version = "py39"
 
 [tool.ruff.format]
 skip-magic-trailing-comma = false
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["pytest_recording"]
 known-third-party = ["_pytest", "packaging", "pytest", "vcr", "yaml"]

--- a/src/pytest_recording/hooks.py
+++ b/src/pytest_recording/hooks.py
@@ -1,5 +1,6 @@
-from _pytest.config import Config
 from typing import TYPE_CHECKING
+
+from _pytest.config import Config
 
 if TYPE_CHECKING:
     from vcr import VCR

--- a/src/pytest_recording/plugin.py
+++ b/src/pytest_recording/plugin.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Iterator, List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
 import pytest
 from _pytest.config import Config, PytestPluginManager

--- a/src/pytest_recording/utils.py
+++ b/src/pytest_recording/utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 from itertools import chain
 from typing import Any, Dict, Iterable, Iterator, List
+
 from _pytest.mark.structures import Mark
 
 ConfigType = Dict[str, Any]

--- a/tests/test_blocking_network.py
+++ b/tests/test_blocking_network.py
@@ -3,7 +3,6 @@ import sys
 from io import BytesIO
 from socket import AF_INET, AF_NETLINK, AF_UNIX, SOCK_RAW, SOCK_STREAM, socket
 
-import pycurl
 import pytest
 import requests
 import vcr.errors

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from pytest_recording.plugin import RECORD_MODES
 
 

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1,10 +1,9 @@
 import json
 import string
+from typing import Any
 
 import pytest
 import yaml
-
-from typing import Any
 
 
 def test_cassette_recording(testdir):

--- a/tests/test_replaying.py
+++ b/tests/test_replaying.py
@@ -1,27 +1,17 @@
 import pytest
+import requests
 import vcr
+
 from pytest_recording._vcr import load_cassette
 
 VCR_VERSION = tuple(map(int, vcr.__version__.split(".")))
 
 
-def test_no_cassette(testdir):
+@pytest.mark.vcr
+def test_no_cassete_vcr_used():
     """If pytest.mark.vcr is applied and there is no cassette - an exception happens."""
-    testdir.makepyfile(
-        """
-        import pytest
-        import requests
-        import vcr
-
-        @pytest.mark.vcr
-        def test_vcr_used():
-            with pytest.raises(vcr.errors.CannotOverwriteExistingCassetteException):
-                requests.get('http://localhost/get')
-    """
-    )
-
-    result = testdir.runpytest()
-    result.assert_outcomes(passed=1)
+    with pytest.raises(vcr.errors.CannotOverwriteExistingCassetteException):
+        requests.get("http://localhost/get")
 
 
 def test_combine_cassettes(testdir, get_response_cassette, ip_response_cassette):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pytest_recording.utils import unique
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     requests
     werkzeug<2.1.0
     pycurl --global-option="--with-{env:PYCURL_SSL_LIBRARY}"
+    xdist: pytest-xdist
 commands =
     coverage run --source=pytest_recording -m pytest {posargs:tests}
 


### PR DESCRIPTION
* fix relint config (the `filename` option have had no effect)
* replace some relint entries with ruff rules
  which are gonna be more comprehensive
* organize ruff rules into correct sections
  didn't notice the warning in my previous PR
* enable isort
  Given that isort was configured I was very confused why it wasn't enabled
* remove unnecessary pytester abstraction
  When reading the tests I noticed a bunch of unnecessary pytester invocations. Maybe there's a case for keeping the same style for each test, but for simple tests that didn't need it I just found it confusing and it'd make debugging trickier. It also stops the code from being covered by linters & type-checkers.



One day I'll get to actually fixing the issues I've been asked to address :sweat_smile: 