### PR TITLE
fix: Use fallback for max filename length on Windows

### DIFF
--- a/src/pytest_recording/_vcr.py
+++ b/src/pytest_recording/_vcr.py
@@ -21,7 +21,12 @@ except ImportError:  # pragma: no cover
 
 from .utils import ConfigType, merge_kwargs, unique, unpack
 
-MAX_FILENAME_LEN = os.pathconf(".", "PC_NAME_MAX")
+try:
+    # Try to get max filename length on Unix-like systems
+    MAX_FILENAME_LEN = os.pathconf(".", "PC_NAME_MAX")
+except (AttributeError, ValueError, OSError):
+    # Fallback for Windows or unsupported systems
+    MAX_FILENAME_LEN = 255
 
 
 def load_cassette(cassette_path: str, serializer: ModuleType) -> Tuple[List, List]:


### PR DESCRIPTION
### Description

Fix https://github.com/kiwicom/pytest-recording/issues/174

### Checklist

- [X] All tests passing