### PR TITLE
chore(deps): bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -20,12 +20,12 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.44.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         language_version: system
@@ -36,17 +36,17 @@ repos:
       - id: relint
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0
+    rev: v1.20.0
     hooks:
       - id: mypy
         additional_dependencies: [ "types-pycurl", "types-PyYAML", "types-requests" ]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.5
+    rev: v0.15.9
     hooks:
       - id: ruff-format
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.5
+    rev: v0.15.9
     hooks:
-      - id: ruff
+      - id: ruff-check


### PR DESCRIPTION
🚨Please review the
[guidelines for contributing](https://github.com/kiwicom/pytest-recording/blob/master/CONTRIBUTING.rst)
to this repository.

### Description

This PR bumps the pre-commit hooks.

Not sure if this would be equivalent to having the repo two times in the config? This way the rev would need to be defined only once.

```yaml
  - repo: https://github.com/astral-sh/ruff-pre-commit
    rev: v0.15.9
    hooks:
      - id: ruff-format
      - id: ruff-check
```

### Checklist

- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Added a changelog entry
- [ ] Extended the README / documentation, if necessary
