### PR TITLE
docs: show ignore_hosts in the vcr_config example (refs #170)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,20 @@ Resulting VCR configs for each test:
 - ``test_one`` - ``{"ignore_localhost": True, "filter_headers": []}``
 - ``test_two`` - ``{"ignore_localhost": True, "filter_headers": ["authorization"], "filter_query_parameters": ["api_key"]}``
 
+The ``vcr_config`` fixture forwards any keyword argument to vcrpy, so ``ignore_hosts``
+and other VCR.py options work directly:
+
+.. code:: python
+
+    import pytest
+
+    @pytest.fixture(scope="module")
+    def vcr_config():
+        return {
+            "filter_headers": ["authorization"],
+            "ignore_hosts": ["169.254.169.254", "metadata.google.internal"],
+        }
+
 You can get access to the used ``VCR`` instance via ``pytest_recording_configure`` hook. It might be useful for registering
 custom matchers, persisters, etc.:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 -------------
 
 - Add support for Python 3.14 and drop EOL 3.9. `#185`_
+- Document ``ignore_hosts`` in the ``vcr_config`` fixture example. `#170`_
 
 `0.13.4`_ - 2025-04-24
 ----------------------
@@ -246,6 +247,7 @@ Added
 .. _#185: https://github.com/kiwicom/pytest-recording/pull/185
 .. _#174: https://github.com/kiwicom/pytest-recording/issues/174
 .. _#172: https://github.com/kiwicom/pytest-recording/issues/172
+.. _#170: https://github.com/kiwicom/pytest-recording/issues/170
 .. _#145: https://github.com/kiwicom/pytest-recording/issues/145
 .. _#118: https://github.com/kiwicom/pytest-recording/pull/118
 .. _#99: https://github.com/kiwicom/pytest-recording/pull/99


### PR DESCRIPTION
Refs #170.

The README explains that the `vcr_config` dict is passed directly to vcrpy under the hood, but the only example uses `filter_headers` and `ignore_localhost`. The reporter in #170 asked specifically about `ignore_hosts`, which works the same way but is not shown.

This PR adds a short paragraph plus a code snippet right after the existing kwargs example. It mirrors the same fixture pattern already used in the README and points back to vcrpy for the full list of options.

### Verified locally

With pytest-recording 0.13.4 and vcrpy 8.1.1:

```python
@pytest.fixture(scope="module")
def vcr_config():
    return {"ignore_hosts": ["httpbin.org"]}
```

A `@pytest.mark.vcr` test that calls `httpbin.org` makes a real network request every run and produces no cassette file, while a sibling test calling another host records normally into `cassettes/`.

### Checklist

- [ ] Created tests which fail without the change - N/A, docs only
- [ ] All tests passing - N/A, no code change
- [x] Added a changelog entry
- [x] Extended the README / documentation
